### PR TITLE
include correct version of jQuery in enrolment page

### DIFF
--- a/templates/newuser_result.php
+++ b/templates/newuser_result.php
@@ -20,6 +20,11 @@
 
 $this->data['header'] = $this->t('{authTiqr:tiqr:header_enrollment}');
 $this->data['jquery'] = array('version' => '1.6', 'core' => true);
+if (sspmod_authTiqr_Helper_VersionHelper::useOldVersion()) {
+    $this->data['jquery'] = array('version' => '1.6', 'core' => true);
+} else {
+    $this->data['jquery'] = array('version' => '1.8', 'core' => true);
+}
 
 $this->includeAtTemplateBase('includes/header.php');
 

--- a/templates/newuser_result.php
+++ b/templates/newuser_result.php
@@ -19,7 +19,7 @@
  */
 
 $this->data['header'] = $this->t('{authTiqr:tiqr:header_enrollment}');
-$this->data['jquery'] = array('version' => '1.6', 'core' => true);
+
 if (sspmod_authTiqr_Helper_VersionHelper::useOldVersion()) {
     $this->data['jquery'] = array('version' => '1.6', 'core' => true);
 } else {


### PR DESCRIPTION
fixes an issue with some SimpleSAMLphp versions where enrolment does not automatically process after scanning an enrolment QR code.